### PR TITLE
Fixed colonists inventories being missaligned after a colonst dies

### DIFF
--- a/TeamProject/GlobalWarmingGame/Interactions/Interactables/Buildings/StorageUnit.cs
+++ b/TeamProject/GlobalWarmingGame/Interactions/Interactables/Buildings/StorageUnit.cs
@@ -9,6 +9,10 @@ using System.Linq;
 
 namespace GlobalWarmingGame.Interactions.Interactables.Buildings
 {
+    /// <summary>
+    /// This class encapsulates a storage unit object<br/>
+    /// This is an <see cref="IInteractable"/> object that will store a single <see cref="ResourceItem"/><br/>
+    /// </summary>
     class StorageUnit : Sprite, IInteractable, IBuildable, IReconstructable
     {
         public List<ResourceItem> CraftingCosts { get; } = new List<ResourceItem>() { new ResourceItem(Resource.Stone, 4),
@@ -16,14 +20,14 @@ namespace GlobalWarmingGame.Interactions.Interactables.Buildings
 
         public List<InstructionType> InstructionTypes { get; private set; }
 
-        public static ResourceItem ResourceItemEmpty = new ResourceItem(new ResourceType());
+        public readonly static ResourceItem EMPTY_RESOURCE_ITEM = new ResourceItem(new ResourceType());
 
         public ResourceItem ResourceItem { get; set; }
 
         [PFSerializable]
         public ResourceItem PFSResourceItem
         {
-            get { return ResourceItem != null ? ResourceItem : ResourceItemEmpty; }
+            get { return ResourceItem != null ? ResourceItem : EMPTY_RESOURCE_ITEM; }
             set { ResourceItem = value; }
         }
 
@@ -68,12 +72,17 @@ namespace GlobalWarmingGame.Interactions.Interactables.Buildings
                                 id: "takeItems",
                                 name: $"Take All {ResourceItem.ResourceType.displayName}",
                                 description: "",
-                                onStart: TakeItems
+                                onStart: TakeAll
                                 )
                     );
             }
         }
 
+        /// <summary>
+        /// Creates the TakeItem <see cref="InstructionType"/>
+        /// </summary>
+        /// <param name="amount">The amount of resource to be taken</param>
+        /// <returns>the take item <see cref="InstructionType"/></returns>
         public InstructionType TakeItemInstruction(int amount)
         {
             return new InstructionType(
@@ -83,7 +92,25 @@ namespace GlobalWarmingGame.Interactions.Interactables.Buildings
                 );
         }
 
+        /// <summary>
+        /// Instruction callback for the take all of the <see cref="ResourceItem"/> and reset the storage unit, so no resource is set.
+        /// </summary>
+        /// <param name="instruction"></param>
+        private void TakeAll(Instruction instruction)
+        {
+            Inventory inventory = instruction.ActiveMember.Inventory;
+            if (inventory.AddItem(ResourceItem))
+            {
+                ResetState();
+            }
 
+        }
+
+        /// <summary>
+        /// Instruction callback for the take item instruction
+        /// </summary>
+        /// <param name="destination">destination inventoy for the items tobe given</param>
+        /// <param name="amount">the amount of the resource item to be given</param>
         private void TakeItem(Inventory destination, int amount)
         {
             if (ResourceItem?.Weight >= amount
@@ -93,6 +120,10 @@ namespace GlobalWarmingGame.Interactions.Interactables.Buildings
             }
         }
 
+        /// <summary>
+        /// Creates the Set Resource <see cref="InstructionType"/>
+        /// </summary>
+        /// <returns></returns>
         private List<InstructionType> CreateSetResourceInstructionTypes()
         {
             return Enum.GetValues(typeof(Resource)).Cast<Resource>()
@@ -107,10 +138,12 @@ namespace GlobalWarmingGame.Interactions.Interactables.Buildings
         }
 
 
+        /// <summary>
+        /// Instruction onComplete callback to set the <see cref="InstructionType"/> of this <see cref="StorageUnit"/>
+        /// </summary>
+        /// <param name="instruction"></param>
         private void SetResource(Instruction instruction)
         {
-            //if(instruction.Type.RequiredResources.Count != 1) throw new Exception($"{this.GetType().ToString()} expected RequiredResources.Count to be 1, but was {instruction.Type.RequiredResources.Count}");
-            //ResourceItem = instruction.Type.RequiredResources[0];
             Resource r = (Resource)Enum.Parse(typeof(Resource), instruction.Type.ID);
             ResourceItem = new ResourceItem(r);
             InstructionTypes.Clear();
@@ -119,8 +152,6 @@ namespace GlobalWarmingGame.Interactions.Interactables.Buildings
                             id: "storeItems",
                             name: $"Store {ResourceItem.ResourceType.displayName}",
                             description: "",
-                            //requiredResources: new List<ResourceItem> { new ResourceItem(ResourceItem.ResourceType, 1) },
-                            //checkValidity: (Instruction i) => i.ActiveMember.Inventory.ContainsType(ResourceItem.ResourceType.ResourceID),
                             onStart: StoreItem
                             );
 
@@ -128,40 +159,44 @@ namespace GlobalWarmingGame.Interactions.Interactables.Buildings
                             id: "takeItems",
                             name: $"Take All {ResourceItem.ResourceType.displayName}",
                             description: "",
-                            onStart: TakeItems
+                            onStart: TakeAll
                             )
                 );
         }
 
-        private void TakeItems(Instruction instruction)
-        {
-            Inventory inventory = instruction.ActiveMember.Inventory;
-            if (inventory.AddItem(ResourceItem))
-            {
-                ResetState();
-            }
-
-        }
+        /// <summary>
+        /// Sets this <see cref="StorageUnit"/>'s state so there is no resource type set.
+        /// </summary>
         private void ResetState()
         {
             this.ResourceItem = null;
             InstructionTypes = CreateSetResourceInstructionTypes();
         }
 
+        /// <summary>
+        /// Instruction callback to store an item in the storage unit
+        /// </summary>
+        /// <param name="instruction"></param>
         private static void StoreItem(Instruction instruction)
         {
             StorageUnit storage = (StorageUnit)instruction.PassiveMember;
+            IInstructionFollower activeMember = instruction.ActiveMember;
 
             if (storage.ResourceItem != null)
             {
-                Inventory inventory = instruction.ActiveMember.Inventory;
+                Inventory inventory = activeMember.Inventory;
                 Resource resourceType = storage.ResourceItem.ResourceType.ResourceID;
 
                 if (inventory.Resources.ContainsKey(resourceType))
                 {
-                    ResourceItem item = inventory.Resources[resourceType];
-                    storage.ResourceItem.Weight += item.Weight;
-                    inventory.RemoveItem(item);
+                    int reserve = activeMember.InventoryRules.ContainsKey(resourceType) ? activeMember.InventoryRules[resourceType] : 0;
+                    ResourceItem item = inventory.Resources[resourceType].Clone();
+                    item.Weight -= reserve;
+                    {
+                        storage.ResourceItem.Weight += item.Weight;
+                        inventory.RemoveItem(item);
+                    }
+                    
                 }
             }
 

--- a/TeamProject/GlobalWarmingGame/Interactions/Interactables/Colonist.cs
+++ b/TeamProject/GlobalWarmingGame/Interactions/Interactables/Colonist.cs
@@ -5,6 +5,7 @@ using GlobalWarmingGame.Action;
 using GlobalWarmingGame.Interactions.Enemies;
 using GlobalWarmingGame.Interactions.Interactables.Buildings;
 using GlobalWarmingGame.ResourceItems;
+using GlobalWarmingGame.Resources;
 using GlobalWarmingGame.UI.Controllers;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -124,8 +125,9 @@ namespace GlobalWarmingGame.Interactions.Interactables
 
         #region Food
         public int Hunger { get; private set; } = 0;
+        private static readonly InstructionType EAT_INSTRUCTION_TYPE = new InstructionType("eat", "Eat", "Eat food", 0, new List<ResourceItem>() { new ResourceItem(ResourceTypeFactory.GetResource(Resource.Food), 15) });
         private float timeUntillNextHungerCheck;
-        private readonly float BASE_FOOD_CONSUMPTION = 12000f;
+        private readonly float BASE_FOOD_CONSUMPTION = 6000f;
         #endregion
         private bool deathSoundPlayed;
         private bool AttackTrigger=false;
@@ -444,20 +446,23 @@ namespace GlobalWarmingGame.Interactions.Interactables
             timeUntillNextHungerCheck -= (float)gameTime.ElapsedGameTime.TotalMilliseconds;
             if (timeUntillNextHungerCheck < 0)
             {
+                Instruction i = new Instruction(EAT_INSTRUCTION_TYPE, 0, this, this);
+                instructions.Enqueue(i, i.Priority);
                 //If the colonist is hungry they take health damage and reset else increase hunger
-                if (Hunger == 5)
+                if (Hunger >= 5)
                 {
                     //If colonist doesn't have food on them, they are starving -1 health
-                    if (!Inventory.RemoveItem(new ResourceItem(Resource.Food, 1)))
-                    {
-                        Health -= 1;
-                    }
-                    else
-                    {
+                    
+                    //if (!Inventory.RemoveItem(new ResourceItem(Resource.Food, 1)))
+                    //{
+                    //    Health -= 1;
+                    //}
+                    //else
+                    //{
                         //Food was eaten, reset hunger
-                        Hunger = 0;
-                        Health = Math.Min(Health + 5, MaxHealth);
-                    }
+                        //Hunger = 0;
+                        //Health = Math.Min(Health + 5, MaxHealth);
+                    //}
                 }
                 else
                 {

--- a/TeamProject/GlobalWarmingGame/Interactions/Interactables/InteractablesFactory.cs
+++ b/TeamProject/GlobalWarmingGame/Interactions/Interactables/InteractablesFactory.cs
@@ -272,7 +272,7 @@ namespace GlobalWarmingGame.Interactions.Interactables
                     return new BigStoneNode(position);
 
                 case Interactable.loot:
-                    List<ResourceItem> loot = new List<ResourceItem> { new ResourceItem(Resource.Shotgun, 1) };
+                    List<ResourceItem> loot = new List<ResourceItem> { new ResourceItem(Resource.MachineParts, 24) };
                     return new Loot(loot, position);
 
                 case Interactable.TallGrass:

--- a/TeamProject/GlobalWarmingGame/Interactions/Interactables/InteractablesFactory.cs
+++ b/TeamProject/GlobalWarmingGame/Interactions/Interactables/InteractablesFactory.cs
@@ -251,7 +251,9 @@ namespace GlobalWarmingGame.Interactions.Interactables
             switch(interactable)
             {
                 case Interactable.Colonist:
-                    return new Colonist(position);
+                    Inventory i = new Inventory(Colonist.COLONIST_DEFAULT_INVENTORY_SIZE);
+                    i.AddItem(new ResourceItem(Resource.Food, 32));
+                    return new Colonist(position, i);
                 case Interactable.Merchant:
                     return new Merchant(position);
                 case Interactable.Farm:

--- a/TeamProject/GlobalWarmingGame/Interactions/Interactables/Merchant.cs
+++ b/TeamProject/GlobalWarmingGame/Interactions/Interactables/Merchant.cs
@@ -18,56 +18,56 @@ namespace GlobalWarmingGame.Interactions.Interactables.Animals
                     Resource.Leather,
                     new List<ResourceItem>()
                     {
-                        new ResourceItem(Resource.Food, 4)
+                        new ResourceItem(Resource.MachineParts, 2)
                     }
                 },
                 {
                     Resource.MachineParts,
                     new List<ResourceItem>()
                     {
-                        new ResourceItem(Resource.Food, 4)
+                        new ResourceItem(Resource.MachineParts, 2)
                     }
                 },
                 {
                     Resource.Axe,
                     new List<ResourceItem>()
                     {
-                        new ResourceItem(Resource.Food, 4)
+                        new ResourceItem(Resource.MachineParts, 2)
                     }
                 },
                 {
                     Resource.Hoe,
                     new List<ResourceItem>()
                     {
-                        new ResourceItem(Resource.Food, 4)
+                        new ResourceItem(Resource.MachineParts, 2)
                     }
                 },
                 {
                     Resource.Pickaxe,
                     new List<ResourceItem>()
                     {
-                        new ResourceItem(Resource.Food, 5)
+                        new ResourceItem(Resource.MachineParts, 2)
                     }
                 },
                 {
                     Resource.Shotgun,
                     new List<ResourceItem>()
                     {
-                        new ResourceItem(Resource.Food, 24)
+                        new ResourceItem(Resource.MachineParts, 12)
                     }
                 },
                 {
                     Resource.Cloth,
                     new List<ResourceItem>()
                     {
-                        new ResourceItem(Resource.Food, 2)
+                        new ResourceItem(Resource.MachineParts, 1)
                     }
                 },
                 {
                     Resource.Coat,
                     new List<ResourceItem>()
                     {
-                        new ResourceItem(Resource.Food, 8)
+                        new ResourceItem(Resource.MachineParts, 4)
                     }
                 }
             };

--- a/TeamProject/GlobalWarmingGame/Resources/IStorage.cs
+++ b/TeamProject/GlobalWarmingGame/Resources/IStorage.cs
@@ -1,5 +1,6 @@
 ﻿using GlobalWarmingGame.ResourceItems;
 using System;
+using System.Collections.Generic;
 
 namespace GlobalWarmingGame.Resources
 {
@@ -9,5 +10,6 @@ namespace GlobalWarmingGame.Resources
         event EventHandler<ResourceItem> InventoryChange;
 
         Inventory Inventory { get; }
+        Dictionary<Resource,int> InventoryRules { get; }
     }
 }

--- a/TeamProject/GlobalWarmingGame/UI/Views/GameView.cs
+++ b/TeamProject/GlobalWarmingGame/UI/Views/GameView.cs
@@ -347,7 +347,16 @@ namespace GlobalWarmingGame.UI.Views
             bottomPanel.RemoveChild(inventories[id]);
             inventories[id].Dispose();
             inventories.Remove(id);
-            
+            UpdateInventoryButtonPositions();
+        }
+
+        private void UpdateInventoryButtonPositions()
+        {
+            int counter = 0;
+            foreach(Entity e in inventoryButtons.Values)
+            {
+                e.Offset = new Vector2(64f * counter++, 0f);
+            }
         }
 
 


### PR DESCRIPTION
Fixed a problem where removing a colonist who wasn't the last colonist added. would result in a void in the inventory buttons for the colonist. It was also possible to have two buttons that overlap. This is now fixed.

Also added Inventory rule foundation. Right now it's hardcoded that colonsits try and keep 15 food in there inventory. The food system needs to change to instead of removing food directly. To add an instruction to the colonist to eat food, Having food as a required resource.